### PR TITLE
Sliding window for history limit

### DIFF
--- a/addons/yat/src/scenes/base_terminal/components/history_component/HistoryComponent.cs
+++ b/addons/yat/src/scenes/base_terminal/components/history_component/HistoryComponent.cs
@@ -19,7 +19,7 @@ public partial class HistoryComponent : Node
     {
         if (History.Count >= _yat!.PreferencesManager.Preferences.HistoryLimit)
         {
-            return;
+            History.RemoveFirst();
         }
 
         CurrentNode = null;


### PR DESCRIPTION
Previously, if the list reached its maximum size, new additions were prevented by an early `return;`. This update replaces` return;` with `History.RemoveFirst();` so you can have 15 (or whatever is the limit) of your latest commands in history, instead of first 15.