### PR TITLE
Screenshot: add a dot between a name and file extension

### DIFF
--- a/addons/yat/src/commands/Ss.cs
+++ b/addons/yat/src/commands/Ss.cs
@@ -63,7 +63,7 @@ public sealed class Ss : ICommand
     private void SaveScreenshot(Viewport viewport, string path, string name, string extension)
     {
         Image image = viewport.GetTexture().GetImage();
-        string fileName = path + name + extension;
+        string fileName = $"{path}{name}.{extension}";
 
         Error err = Error.Ok;
         switch (extension)


### PR DESCRIPTION
Dot was missing, causing the screenshot to save with a name like `1730332201589png`. This PR adds the dot that provides the correct file extension.